### PR TITLE
fix (readme): use 'password' provider and flow in email authentication

### DIFF
--- a/src/lib/sveltekit/README.md
+++ b/src/lib/sveltekit/README.md
@@ -179,9 +179,14 @@ For email/password authentication:
 
   const { signIn } = useAuth();
   
-  // With params (e.g., for email+password)
+  // Register new user or login if exists
+  function handleEmailSignUp(email, password) {
+    signIn('password', { email, password, flow: 'signUp' });
+  }
+
+  // Login
   function handleEmailSignIn(email, password) {
-    signIn('email', { email, password });
+    signIn('password', { email, password, flow: 'signIn' });
   }
 </script>
 ```


### PR DESCRIPTION
The provider in the `signIn` function needs to be 'password' for the email&password authentication. Otherwise you get an error as described in #3.

Also, the 'password' provider requires the `flow` param to be set, with to 'signUp' or 'signIn'.